### PR TITLE
Fix commander edge resurrection

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,10 @@
+name: Lua Tests
+on:
+  pull_request:
+jobs:
+  lua:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run Lua tests
+        run: ./tools/run-lua-tests.sh tests/test_edge_resurrection.lua

--- a/luarules/gadgets/unit_clamp_position.lua
+++ b/luarules/gadgets/unit_clamp_position.lua
@@ -1,0 +1,45 @@
+local gadget = gadget
+
+function gadget:GetInfo()
+    return {
+        name = "Unit Clamp Position",
+        desc = "Ensures units spawn fully in-bounds",
+        author = "codex",
+        date = "2025",
+        license = "GNU GPL, v2 or later",
+        layer = -1,
+        enabled = true
+    }
+end
+
+if not gadgetHandler:IsSyncedCode() then
+    return
+end
+
+local worldMinX = Game.mapSizeX - Game.mapSizeX
+local worldMaxX = Game.mapSizeX
+local worldMinZ = Game.mapSizeZ - Game.mapSizeZ
+local worldMaxZ = Game.mapSizeZ
+
+local function Clamp(value, min, max)
+    if value < min then return min end
+    if value > max then return max end
+    return value
+end
+
+local function ClampUnitPosition(unitID, unitDefID)
+    local x, y, z = Spring.GetUnitPosition(unitID)
+    if not x then return end
+    local radius = UnitDefs[unitDefID].radius or 0
+    local cx = Clamp(x, worldMinX + radius, worldMaxX - radius)
+    local cz = Clamp(z, worldMinZ + radius, worldMaxZ - radius)
+    if cx ~= x or cz ~= z then
+        Spring.SetUnitPosition(unitID, cx, cz)
+    end
+end
+
+function gadget:UnitCreated(unitID, unitDefID)
+    ClampUnitPosition(unitID, unitDefID)
+end
+
+return

--- a/tests/test_edge_resurrection.lua
+++ b/tests/test_edge_resurrection.lua
@@ -1,0 +1,15 @@
+-- Regression test for commander resurrection at the map edge
+function test()
+    local worldMinX = Game.mapSizeX - Game.mapSizeX -- should be 0
+    local spawnZ = Game.mapSizeZ * 0.5
+    local spawnY = Spring.GetGroundHeight(worldMinX, spawnZ)
+    local featureID = Spring.CreateFeature("armcom_dead", worldMinX - 20, spawnY, spawnZ)
+    assert(featureID, "failed to create commander wreck")
+
+    local unitID = Spring.ResurrectUnit(featureID)
+    assert(unitID, "resurrect returned nil")
+    assert(not Spring.GetUnitIsDead(unitID), "unit is dead after resurrection")
+
+    local x, y, z = Spring.GetUnitPosition(unitID)
+    assert(Spring.TestMoveOrder(Spring.GetUnitDefID(unitID), x, y, z), "unit cannot move from edge")
+end

--- a/tools/run-lua-tests.sh
+++ b/tools/run-lua-tests.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+if command -v luajit >/dev/null 2>&1; then
+    LUA=luajit
+elif command -v lua >/dev/null 2>&1; then
+    LUA=lua
+else
+    echo "Lua interpreter not found" >&2
+    exit 1
+fi
+
+if [ $# -eq 0 ]; then
+    echo "Usage: $0 <testfile.lua>" >&2
+    exit 1
+fi
+
+"$LUA" "$1"


### PR DESCRIPTION
## Summary
- add unit position clamp gadget to keep resurrected units in-bounds
- add regression test for edge resurrection behaviour
- add simple Lua test runner and wire it into CI

## Testing
- `./tools/run-lua-tests.sh tests/test_edge_resurrection.lua` *(fails: Lua interpreter not found)*